### PR TITLE
add proper package zip to every published release

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -17,7 +17,7 @@ jobs:
         mkdir ./PayonePayment
         cp -r src CHANGELOG* README.md composer.json ./PayonePayment/
     - name: Build the zip
-      uses: thedoctor0/zip-release@master
+      uses: thedoctor0/zip-release@v0.2.1
       with:
         path: ./PayonePayment/
         filename: PayonePayment-${{ env.RELEASE_VERSION }}.zip

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,28 @@
+name: Create Download on Release
+on: 
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Master
+      uses: actions/checkout@master      
+    - name: Set Tag env
+      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:10}
+    - name: Test tag
+      run: echo ${{ env.RELEASE_VERSION }}
+    - name: Prepare folder
+      run: |
+        mkdir ./PayonePayment
+        cp -r src CHANGELOG* README.md composer.json ./PayonePayment/
+    - name: Build the zip
+      uses: thedoctor0/zip-release@master
+      with:
+        path: ./PayonePayment/
+        filename: PayonePayment-${{ env.RELEASE_VERSION }}.zip
+    - name: Upload zip to release
+      uses: fnkr/github-action-ghr@v1
+      env:
+        GHR_PATH: PayonePayment-${{ env.RELEASE_VERSION }}.zip
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This addition to Github Actions will create a zip file with the correct naming and only needed files and attach this to every published release as artifact.