### PR TITLE
Fix wrong router in Paypal Express checkout

### DIFF
--- a/src/DependencyInjection/controllers.xml
+++ b/src/DependencyInjection/controllers.xml
@@ -95,7 +95,7 @@
             <argument type="service" id="country.repository"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\SalesChannelContextSwitcher" />
             <argument type="service" id="PayonePayment\Components\CartHasher\CartHasher" />
-            <argument type="service" id="router.default" />
+            <argument type="service" id="Shopware\Storefront\Framework\Routing\Router"/>
 
             <call method="setContainer">
                 <argument type="service" id="service_container"/>


### PR DESCRIPTION
if you have sales channels with suffixes like (host)/de-de, ....
then a paypal express checkout will lead to a "domain not found in sales channels" errors.

because the "de-de" is just not used in the router when building it

the reason is, because you accidentally used the router.default from symfony
and not the storefront router of shopware which already considers these suffixes

i did also check the router.default usage in the global-handler DI xml from you.
this still works because the payone_redirect route is not a storefront route...so it "accidentally" works,
but you might still want to test all...maybe some other errors exist due to this which i am not aware of

thank you