### PR TITLE
[noticket] Ensure custom field for clearing bank account data exists.

### DIFF
--- a/src/Components/TransactionHandler/Capture/CaptureTransactionHandler.php
+++ b/src/Components/TransactionHandler/Capture/CaptureTransactionHandler.php
@@ -108,7 +108,9 @@ class CaptureTransactionHandler extends AbstractTransactionHandler implements Ca
      */
     private function updateClearingBankAccountData(array $payoneResponse): void
     {
-        $currentClearingBankAccountData = $this->paymentTransaction->getCustomFields()[CustomFieldInstaller::CLEARING_BANK_ACCOUNT];
+        $customFields = $this->paymentTransaction->getCustomFields();
+
+        $currentClearingBankAccountData = $customFields[CustomFieldInstaller::CLEARING_BANK_ACCOUNT] ?? [];
         $newClearingBankAccountData     = $payoneResponse['clearing']['BankAccount'] ?? null;
 
         if (!empty($newClearingBankAccountData)) {


### PR DESCRIPTION
May otherwise result in error "Notice: Undefined index: payone_clearing_bank_account" preventing payment status update on capture.

I noticed this with a partial capture for a credit card order.