### PR TITLE
Noticket: Fix MySQL issues w/PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:
-        - 3306
+        - 3306:3306
     steps:
     - name: Checkout
       uses: actions/checkout@master
@@ -35,8 +35,6 @@ jobs:
       run: composer -V
     - name: Check PHP Extensions
       run: php -m
-    - name: Start MySQL
-      run: sudo /etc/init.d/mysql start
     - name: Composer setup
       run: composer install --prefer-dist --no-ansi --no-interaction --no-progress --optimize-autoloader
     - name: Codestyle
@@ -47,7 +45,7 @@ jobs:
         git clone --depth 1 --single-branch -b ${{ matrix.shopware-versions }} https://github.com/shopware/development /tmp/shopware
         mkdir /tmp/shopware/custom/plugins/PayonePayment
         cp -r * /tmp/shopware/custom/plugins/PayonePayment/
-        printf "const:\n    APP_ENV: \"dev\"\n    APP_URL: \"http://localhost\"\n    DB_HOST: \"localhost\"\n    DB_PORT: \"3306\"\n    DB_NAME: \"shopware\"\n    DB_USER: \"root\"\n    DB_PASSWORD: \"root\"" > /tmp/shopware/.psh.yaml.override
+        printf "const:\n    APP_ENV: \"dev\"\n    APP_URL: \"http://localhost\"\n    DB_HOST: \"127.0.0.1\"\n    DB_PORT: \"3306\"\n    DB_NAME: \"shopware\"\n    DB_USER: \"root\"\n    DB_PASSWORD: \"root\"" > /tmp/shopware/.psh.yaml.override
         cd /tmp/shopware
         php psh.phar init
         composer install --prefer-dist --no-ansi --no-interaction --no-progress --optimize-autoloader --no-scripts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     name: Shopware ${{ matrix.shopware-versions }} on PHP ${{ matrix.php-versions }}
     services:
       mysql:
-        image: mysql:5.7.27
+        image: mariadb:latest
         env:
           MYSQL_ROOT_PASSWORD: root
         ports:


### PR DESCRIPTION
Using MySQL service container pinned at version 5.7.27 instead of builtin MySQL of runner that got bumped to MySQL 8.0 (which broke builds with PHP 7.2 and 7.3)