### PR TITLE
version bump to 230-a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,6 @@ Bugfixes
  
 Maintenance
  
-* Shopware 6.4.3 compatibility
+* Shopware 6.4.3.1 compatibility
 * massive refactoring effort
 * Elasticsearch compatibility

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -86,3 +86,22 @@ Wartung
  
 * getestet mit Shop-Version 6.4.1.0
 * bessere Übersetzungen der Fehlermeldungen
+
+
+# 2.3.0
+
+Neue Funktionen
+ 
+* neue PAYONE Berechtigungsverwaltung
+* Status Mapping pro Zahlungsmethode möglich
+ 
+Fehlerbehebungen
+ 
+* Fix für die Freischaltung der Schaltfläche "Jetzt kaufen"
+* PayPal Express: Telefonnummer ist kein Pflichtfeld mehr
+ 
+Wartung
+ 
+* getestet mit Shopware 6.4.3.1
+* massive Überarbeitungen in der Pluginstruktur
+* Elasticsearch Kompatibilität hergestellt

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payone-gmbh/shopware-6",
   "type": "shopware-platform-plugin",
   "description": "PAYONE Payment Plugin",
-  "version": "2.3.0-beta.1",
+  "version": "2.3.0",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
New Features
 
* new PAYONE permissions management
* status mapping per payment method possible
 
Bugfixes
 
* fix for unlock the buy now button
* PayPal Express: telephone number not a mandatory field 
 
Maintenance
 
* Shopware 6.4.3.1 compatibility
* massive refactoring effort
* Elasticsearch compatibility