### PR TITLE
Fix plugin-rules/no-src-imports

### DIFF
--- a/src/Resources/app/administration/src/module/payone-notification-target/page/payone-notification-target-list/index.js
+++ b/src/Resources/app/administration/src/module/payone-notification-target/page/payone-notification-target-list/index.js
@@ -1,6 +1,5 @@
 import template from './payone-notification-target-list.html.twig';
-import { Component, Mixin } from 'src/core/shopware';
-const { Criteria } = Shopware.Data;
+const { Component, Mixin, Data: { Criteria } } = Shopware;
 
 Component.register('payone-notification-target-list', {
     template,


### PR DESCRIPTION
Fixes the administration build error:

```     
    ERROR in 
    /shopware/vendor/payone-gmbh/shopware-6/src/Resources/app/administration/src/module/payone-notification-target/page/payone-notification-target-list/index.js
    2:34  error  You can't use imports directly from the Shopware Core via "src/core/shopware". 
    Use the global Shopware object directly instead (https://developer.shopware.com/docs/guides/plugins/plugins/administration/the-shopware-object)  plugin-rules/no-src-imports
```

Error occures on shopware v6.4.5.0

See: https://developer.shopware.com/docs/guides/plugins/plugins/administration/the-shopware-object

