### PR TITLE
version bump to 241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,3 +146,25 @@ Maintenance
 
 * Compatibility with 0€ orders
 * tested with 6.4.1
+
+# 2.4.1
+
+New Features
+
+* Deactivate payone payment methods on zero amount carts
+* Add apple-pay
+* Add payment method description
+
+Bugfixes
+
+* Fix config loading error
+* Fix storefront requests
+* Fix missing service
+* Fix missing customer parameter on prepayment
+
+Maintenance
+
+* Fix backwards compatibility
+* Removed cardtype type discover
+* Add dependency to GitHub pipeline
+* Add fix for Version 6.4.5.0

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -142,3 +142,25 @@ Wartung
 
 * Kompatibel mit 0€ Bestellungen
 * getestet mit 6.4.1
+
+# 2.4.1
+
+Neue Funktionen
+
+* PAYONE Zahlungsarten für 0€ Bestellungen gesperrt
+* Apple-pay hinzugefügt
+* Zahlartenbeschreibung hinzugefügt
+
+Fehlerbehebungen
+
+* Fehler beim Laden der Konfiguration behoben
+* Storefront Anfragen korrigiert
+* Fehlende Services behoben
+* Fehlender Parameter bei der Vorkasse hinzugefügt
+
+Wartung
+
+* Abwärtskompatibilität beheben
+* Kartentyp Discover entfernt
+* Abhängigkeit zur GitHub-Pipeline hinzufügen
+* getestet mit 6.4.5.0

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payone-gmbh/shopware-6",
   "type": "shopware-platform-plugin",
   "description": "PAYONE Payment Plugin",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
New Features

deactivate payone payment methods on zero amount carts
add apple-pay
add payment method description

Bugfixes

fix config loading error
fix storefront requests
fix missing service
fix missing customer parameter on prepayment

Maintenance

fix backwards compatibility
Removed cardtype type discover
Add dependency to GitHub pipeline
Add fix for Version 6.4.5.0