### PR TITLE
version bump to 300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,3 +168,16 @@ Maintenance
 * Removed cardtype type discover
 * Add dependency to GitHub pipeline
 * Add fix for Version 6.4.5.0
+
+# 3.0.0
+
+Bugfixes
+
+* Customer deletion now possible
+* Refund only from not yet refunded items possible
+* Adjustment missing dependencies when installing via store
+
+Maintenance
+
+* fix compatibility 6.4.7.0
+* drop support for 6.2

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -164,3 +164,16 @@ Wartung
 * Kartentyp Discover entfernt
 * Abhängigkeit zur GitHub-Pipeline hinzufügen
 * getestet mit 6.4.5.0
+
+# 3.0.0
+
+Fehlerbehebungen
+
+* Löschung von Kunden ist jetzt möglich
+* Gutschrift nur bei noch nicht gutgeschriebenen Artikeln möglich
+* Fehlende Abhängigkeiten hinzugefügt für die Installation via Store
+
+Wartung
+
+* Kompatibilität zu 6.4.7.0 hergestellt
+* Unterstützung für 6.2 entfernt

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payone-gmbh/shopware-6",
   "type": "shopware-platform-plugin",
   "description": "PAYONE Payment Plugin",
-  "version": "2.4.1",
+  "version": "3.0.0",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
# 3.0.0

Bugfixes

* Customer deletion now possible
* Refund only from not yet refunded items possible
* Adjustment missing dependencies when installing via store

Maintenance

* fix compatibility 6.4.7.0
* drop support for 6.2