### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,9 +101,13 @@ jobs:
           mkdir -p /tmp/shopware
           git clone --depth 1 --single-branch -b ${{ matrix.shopware-versions }} https://github.com/shopware/development /tmp/shopware
           printf "const:\n    APP_ENV: \"dev\"\n    APP_URL: \"http://localhost\"\n    DB_HOST: \"127.0.0.1\"\n    DB_PORT: \"3306\"\n    DB_NAME: \"shopware\"\n    DB_USER: \"root\"\n    DB_PASSWORD: \"root\"" > /tmp/shopware/.psh.yaml.override
+          rm -rf /tmp/shopware/platform
+          git clone --depth 1 --single-branch -b ${{ matrix.shopware-versions }} https://github.com/shopware/platform /tmp/shopware/platform
           cd /tmp/shopware
           php psh.phar init
-          composer install --prefer-dist --no-ansi --no-interaction --no-progress --optimize-autoloader --no-scripts
+          cd /tmp/shopware/vendor/shopware/platform
+          wget https://github.com/shopware/platform/commit/0e6cbc24383f0123c01f59bd9aae0a49ce739cca.patch
+          patch -p1 -N < 0e6cbc24383f0123c01f59bd9aae0a49ce739cca.patch || true
       - name: Install plugin
         run: |
           mkdir -p /tmp/shopware/custom/plugins/PayonePayment


### PR DESCRIPTION
When running `php psh.phar init` the composer.lock of the development template is always deleted first, so not necessarily the version of `shopware/platform`, for which you cloned the development template, was installed. This is solved with this PR by cloning the correct version of `shopware/platform` into the "platform" folder of the development template.

On top of that a shopware bug for the versions 6.4.2.0 - 6.4.7.0 is fixed by applying a patch to `shopware/platform`.