### PR TITLE
version bump to 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,11 +237,31 @@ Maintenance
 
 # 4.0.0
 
-Maintenance
+New Features
+ 
+* Shopware 6.3 support removed
+* General code optimizations implemented
 
-* drop support for 6.3
-* general code improvements
-* customFields on orderTransaction for storing payone transaction data have been replaced by an entity extension
+* Important change: The transaction data of PAYONE payments was 
+previously always stored in the additional fields of the orders. 
+Since the additional fields are stored as JSON in the database, 
+searching the transaction data was not very performant for large 
+amounts of data. Therefore, an entity extension was set up for 
+the transaction data so that the data is stored in an extra database 
+table that can be searched much more performantly. During the plugin 
+update, the old additional fields are migrated to the entity extension 
+and then the additional fields are deleted. If you have used our 
+additional fields in your own code or for example in the synchronization 
+to external systems, you have to adapt this to the new entity extension.
+ 
+Bugfix
+ 
+* Remove deletion of saved credit cards
+ 
+Maintenance
+ 
+* Remove BIC from debit
+* Tested with 6.4.16
 
 ### Read transaction data ###
 ```        

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -234,11 +234,32 @@ Wartung
 
 # 4.0.0
 
+Neue Funktionen
+
+* Unterstützung für Shopware 6.3 aufgehoben
+* Allgemeine Code Optimierungen durchgeführt
+
+* Wichtige Änderung: Die Transaktionsdaten von PAYONE Zahlungen 
+wurden bisher immer in den Zusatzfeldern der Bestellungen gespeichert. 
+Da die Zusatzfelder als JSON in der Datenbank gespeichert werden, 
+war das Durchsuchen der Transaktionsdaten bei großen Datenmengen nicht 
+sehr performant. Deshalb wurde für die Transaktionsdaten eine Entity 
+Extension eingerichtet, sodass die Daten in einer extra Datenbanktabelle 
+gespeichert werden, die deutlich performanter durchsucht werden kann. 
+Beim Plugin Update werden die alten Zusatzfelder in die Entity Extension 
+migriert und danach werden die Zusatzfelder gelöscht. Sollten Sie in Ihrem 
+eigenen Code oder zum Beispiel bei der Synchronisation zu externen Systemen 
+unsere Zusatzfelder verwendet haben, müssen Sie das auf die neue Entity 
+Extension anpassen.
+
+Fehlerbehebung
+
+* Löschung gespeicherter Kreditkarten entfernt
+
 Wartung
 
-* Unterstützung für 6.3 entfernt
-* Allgemeine Code Optimierungen
-* Die Transaktionsdaten wurden von den customFields in eine EntityExtension verlagert
+* BIC aus der Lastschrift entfernt
+* Getestet mit 6.4.16
 
 ### Lesen der Transaktionsdaten ###
 ```        


### PR DESCRIPTION
New Features
 
* Shopware 6.3 support removed
* General code optimizations implemented

* Important change: The transaction data of PAYONE payments was 
previously always stored in the additional fields of the orders. 
Since the additional fields are stored as JSON in the database, 
searching the transaction data was not very performant for large 
amounts of data. Therefore, an entity extension was set up for 
the transaction data so that the data is stored in an extra database 
table that can be searched much more performantly. During the plugin 
update, the old additional fields are migrated to the entity extension 
and then the additional fields are deleted. If you have used our 
additional fields in your own code or for example in the synchronization 
to external systems, you have to adapt this to the new entity extension.
 
Bugfix
 
* Remove deletion of saved credit cards
 
Maintenance
 
* Remove BIC from debit
* Tested with 6.4.16