### PR TITLE
fix(account): add missing route scope annotation

### DIFF
--- a/src/Storefront/Controller/Account/AccountOrderControllerDecorator.php
+++ b/src/Storefront/Controller/Account/AccountOrderControllerDecorator.php
@@ -8,6 +8,7 @@ use PayonePayment\PaymentHandler\PaymentHandlerGroups;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\AccountOrderController;
 use Shopware\Storefront\Controller\StorefrontController;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Route(defaults={"_routeScope": {"storefront"}})
+ * @RouteScope(scopes={"storefront"})
  */
 class AccountOrderControllerDecorator extends StorefrontController
 {


### PR DESCRIPTION
Without that annotation:
- the vendor/shopware/core/Framework/Routing/RouteScopeCheckTrait.php throws "Call to a member function getScopes() on array"
- the vendor/shopware/storefront/Framework/Routing/ResponseHeaderListener.php:22 throws "Uncaught Error: Call to a member function hasScope() on array"

All that leads into a 500 page on accessing the Account > Order Overview Page