### PR TITLE
PAYOSWXP-93: improve support for vouchers

### DIFF
--- a/src/Components/Hydrator/LineItemHydrator/LineItemHydrator.php
+++ b/src/Components/Hydrator/LineItemHydrator/LineItemHydrator.php
@@ -296,11 +296,6 @@ class LineItemHydrator implements LineItemHydratorInterface
             $item['pr'] = $this->currencyPrecision->getRoundedItemAmount($item['pr'], $currency);
             $item['va'] = $this->currencyPrecision->getRoundedItemAmount($item['va'], $currency);
 
-            if ($item['pr'] <= 0) {
-                // price is does not have a positive price - skip it
-                continue;
-            }
-
             foreach ($item as $key => $value) {
                 $payoneList[sprintf('%s[%d]', $key, $index)] = $value;
             }


### PR DESCRIPTION
+ cart-validation failed if more than two vouchers was applied (cause different sort-orders between create initial hash and validate hash against placed order)
+ remove exclude vouchers from line-item hydrator