### PR TITLE
Update README.md - added refresh command for plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The plugin can easily be integrated via Composer:
 
 ```
 composer require payone-gmbh/shopware-6
+php bin/console plugin:refresh
 php bin/console plugin:install PayonePayment
 php bin/console plugin:activate PayonePayment
 php bin/console cache:clear


### PR DESCRIPTION
As shown in [the docs](https://developer.shopware.com/docs/guides/plugins/plugins/plugin-base-guide#install-your-plugin), you need to refresh the list of plugins before you can install a plugin