### PR TITLE
PAYOSWXP-100: Unzer invoice purchase: if the customer has a company address, the birthday is not required

### DIFF
--- a/src/PaymentHandler/PayonePayolutionInvoicingPaymentHandler.php
+++ b/src/PaymentHandler/PayonePayolutionInvoicingPaymentHandler.php
@@ -18,7 +18,11 @@ class PayonePayolutionInvoicingPaymentHandler extends AbstractSynchronousPayoneP
         $definitions = parent::getValidationDefinitions($salesChannelContext);
 
         $definitions['payolutionConsent'] = [new NotBlank()];
-        $definitions['payolutionBirthday'] = [new NotBlank(), new Birthday(['value' => $this->getMinimumDate()])];
+
+        // if the customer has a company address, the birthday is not required
+        if ($salesChannelContext->getCustomer()?->getDefaultBillingAddress()?->getCompany() === null) {
+            $definitions['payolutionBirthday'] = [new NotBlank(), new Birthday(['value' => $this->getMinimumDate()])];
+        }
 
         $configuration = $this->configReader->read($salesChannelContext->getSalesChannel()->getId());
 

--- a/src/Resources/views/storefront/payone/payolution/consent-checkbox.html.twig
+++ b/src/Resources/views/storefront/payone/payolution/consent-checkbox.html.twig
@@ -1,4 +1,6 @@
 {% block payone_payolution_consent_checkbox %}
+
+    {% if context.customer.activeBillingAddress and context.customer.activeBillingAddress.company is empty %}
     <div class="row consent-row">
         <div class="col-12">
             <label class="form-label" for="payolutionBirthday">
@@ -17,6 +19,7 @@
             />
         </div>
     </div>
+    {% endif %}
 
     <div class="row consent-row">
         <div class="col-12">


### PR DESCRIPTION
The date of birth should no longer be requested on the payment type page as soon as something has been entered in the Company name field.