### PR TITLE
PAYOSWXP-117: iDeal payment: add new issuer list for iDeal

### DIFF
--- a/src/PaymentHandler/PayoneIDealPaymentHandler.php
+++ b/src/PaymentHandler/PayoneIDealPaymentHandler.php
@@ -28,6 +28,8 @@ class PayoneIDealPaymentHandler extends AbstractAsynchronousPayonePaymentHandler
         'TRIODOS_BANK',
         'VAN_LANSCHOT_BANKIERS',
         'YOURSAFE',
+        'NATIONALE_NEDERLANDEN',
+        'N26',
     ];
 
     public static function isCapturable(array $transactionData, array $payoneTransActionData): bool
@@ -36,7 +38,7 @@ class PayoneIDealPaymentHandler extends AbstractAsynchronousPayonePaymentHandler
             return false;
         }
 
-        $txAction = isset($transactionData['txaction']) ? strtolower((string) $transactionData['txaction']) : null;
+        $txAction = isset($transactionData['txaction']) ? strtolower((string)$transactionData['txaction']) : null;
 
         if ($txAction === TransactionStatusService::ACTION_PAID) {
             return true;

--- a/src/Resources/views/storefront/payone/ideal/ideal-form.html.twig
+++ b/src/Resources/views/storefront/payone/ideal/ideal-form.html.twig
@@ -39,6 +39,8 @@
                     <option value="TRIODOS_BANK">Triodos Bank</option>
                     <option value="VAN_LANSCHOT_BANKIERS">van Lanschot</option>
                     <option value="YOURSAFE">Yoursafe B.V</option>
+                    <option value="NATIONALE_NEDERLANDEN">Nationale-Nederlanden</option>
+                    <option value="N26">N26</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
The issuer list for **iDeal** has updated! 

> new issuer list:

- ABN Amro Bank
- ASN Bank
- ING Bank
- Rabobank
- SNS Bank
- SNS Regio Bank
- Triodos Bank
- Van Lanschot Kempen
- Knab Bank
- Bunq Bank
- Revolut
- Yoursafe
- **Nationale-Nederlanden** 
- **N26**