### PR TITLE
Version bump 602

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,3 +394,15 @@ Maintenance
 Bugfix
 
 * removed old .js file
+
+# 6.0.2
+
+Attention: This plugin was developed exclusively for Shopware 6.5! It is not suitable for Shopware 6.6.
+
+Bugfix
+
+* Fix problem with .js error in Shopware 6.5
+
+Maintenance
+
+* tested with Shopware 6.5.18

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -381,3 +381,15 @@ Wartung
 Fehlerbehebung
 
 * alte .js Datei entfernt
+
+# 6.0.2
+
+Achtung: Dieses Plugin wurde ausschließlich für Shopware 6.5 entwickelt! Es ist nicht geeignet für Shopware 6.6.
+
+Fehlerbehebung
+
+Problem mit .js Fehler in Shopware 6.5 behoben
+
+Wartung
+
+getestet mit Shopware 6.5.18

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payone-gmbh/shopware-6",
   "type": "shopware-platform-plugin",
   "description": "PAYONE Payment Plugin",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
**Attention: This plugin was developed exclusively for Shopware 6.5! It is not suitable for Shopware 6.6.**

Bugfix

- Fix problem with .js error in Shopware 6.5

Maintenance

- tested with Shopware 6.5.18