### PR TITLE
version bump to 610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -394,3 +394,23 @@ Maintenance
 Bugfix
 
 * removed old .js file
+
+# 6.1.0
+
+New Features
+ 
+* enable line items for all payment methods
+* add line item details in order details page
+ 
+Bugfixes
+ 
+* fixed problems with payment filter
+* fixed problems with rights assignment
+* fixed problem with Notification Forward Detail Page (Thanks @hgnb99)
+* fixed problem with Apple Pay
+ 
+Maintenance
+ 
+* add credit card holder
+* removed storage of SEPA mandates
+* tested with 6.6.5.1

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -381,3 +381,23 @@ Wartung
 Fehlerbehebung
 
 * alte .js Datei entfernt
+
+# 6.1.0
+
+Neue Funktionen
+ 
+* Einzelartikelübergabe für alle Zahlungsarten aktivierbar
+* Hinzufügen von Artikeldetails auf der Bestellungsdetailseite
+ 
+Fehlerbehebungen
+ 
+* Probleme mit dem Zahlungsfilter behoben
+* Probleme mit der Rechtevergabe behoben
+* Problem mit der Benachrichtigungsweiterleitungs-Detailseite behoben (Danke @hgnb99)
+* Problem mit Apple Pay behoben
+ 
+Wartung
+ 
+* Kreditkarteninhaber hinzufügen
+* Speicherung von SEPA-Mandaten entfernt
+* getestet mit 6.6.5.1

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payone-gmbh/shopware-6",
   "type": "shopware-platform-plugin",
   "description": "PAYONE Payment Plugin",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
New Features
 
* enable line items for all payment methods
* add line item details in order details page
 
Bugfixes
 
* fixed problems with payment filter
* fixed problems with rights assignment
* fixed problem with Notification Forward Detail Page (Thanks @hgnb99)
* fixed problem with Apple Pay
 
Maintenance
 
* add credit card holder
* removed storage of SEPA mandates
* tested with 6.6.5.1