### PR TITLE
version bump to 630

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,3 +431,18 @@ Maintenance
  
 * webhooks: add sort-order for handlers to prevent wrong order
 * tested with 6.6.9
+
+# 6.3.0
+
+Bugfixes
+
+* Problem with the non-transmitted phone number has been fixed
+* Fixed payment-filter on empty cart
+* Validation of different shipping address has been fixed
+
+Maintenance
+
+* Add state for specific countries
+* Change webhook for prepayment auto capture to 'paid'
+* Remove bankgrouptype parameter for iDEAL
+* tested with 6.6.10.5

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -418,3 +418,18 @@ Wartung
  
 * webhooks: Sortierreihenfolge für Handler hinzugefügt
 * getestet mit 6.6.9
+
+# 6.3.0
+
+Fehlerbehebung
+
+* Das Problem mit der nicht übertragenen Telefonnummer wurde behoben
+* Der Fehler im Zahlungsfilter bei leerem Warenkorb wurde behoben
+* Die Validierung verschiedener Versandadressen wurde behoben
+
+Wartung
+
+* Bundesstaaten für bestimmte Länder hinzugefügt
+* Webhook für die automatische Vorkasse auf 'paid' geändert
+* Bankgruppentyp-Parameter für iDEAL entfernt
+* getestet mit 6.6.10.5


### PR DESCRIPTION
Bugfixes
 
* Problem with the non-transmitted phone number has been fixed
* Fixed payment-filter on empty cart
* Validation of different shipping address has been fixed
 
Maintenance
 
* Add state for specific countries
* Change webhook for prepayment auto capture to 'paid'
* Remove bankgrouptype parameter for iDEAL
* tested with 6.6.10.5