### PR TITLE
Fix occasional error during plugin update in PaymentMethodInstaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -493,3 +493,9 @@ Bugfixes
 Maintenance
 
 * Tested with 6.7.4.2
+
+# unreleased
+
+Bugfixes
+
+* Fixed an occasional error during plugin update in PaymentMethodInstaller

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -480,3 +480,9 @@ Fehlerbehebung
 Wartung
 
 * Getestet mit 6.7.4.2
+
+# unreleased
+
+Fehlerbehebung
+
+* Ein gelegentlich auftretender Fehler beim Plugin-Update in PaymentMethodInstaller wurde behoben.

--- a/src/Installer/PaymentMethodInstaller.php
+++ b/src/Installer/PaymentMethodInstaller.php
@@ -62,7 +62,7 @@ class PaymentMethodInstaller implements InstallerInterface
              * @noinspection UsingInclusionOnceReturnValueInspection
              * @var list<class-string<PaymentMethodInterface>> $payonePaymentMethods
              */
-            $payonePaymentMethods = (array) require_once $configurationFile;
+            $payonePaymentMethods = (array) require $configurationFile;
         }
 
         self::$cache = $payonePaymentMethods;


### PR DESCRIPTION
for background info see the support ticket for Merchant ID 26753

Explanation of bug/fix: In rare cases, the class may have been already instantiated (e.g. by compiler pass), when plugin:update is run. In these cases, require_once just returns true.