### PR TITLE
version bump to 720

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,9 +498,9 @@ Maintenance
 
 New Features
 
-* Payla Clearing details are now stored and shown on invoices
+* Clearing details for PAYONE Secured Invoice are now stored and shown on invoices
 
-Bugfix
+Bugfixes
 
 * Delivery of gross prices for line items and shipping positions in payment requests (also for B2B customers)
 * Compatibility established from Shopware version 6.7.5.0 onwards

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -485,7 +485,7 @@ Wartung
 
 Neue Funktionen
 
-* Payla Clearing-Daten werden gespeichert und auf Rechnungen ausgegeben
+* Bezahlinformationen werden nun für den PAYONE gesicherten Rechungskauf gespeichert und auf Rechnungen ausgegeben
 
 Fehlerbehebung
 


### PR DESCRIPTION
New Features

- Clearing details for PAYONE Secured Invoice are now stored and shown on invoices

Bugfixes

- Delivery of gross prices for line items and shipping positions in payment requests (also for B2B customers)
- Compatibility established from Shopware version 6.7.5.0 onwards
- Fixed an occasional error during plugin update in PaymentMethodInstaller
- Fixed Ratepay payment handling

Maintenance

- Tested with 6.7.6.2