### PR TITLE
Bump Apple Pay SDK version

### DIFF
--- a/src/Provider/ApplePay/EventListener/CheckoutConfirmApplePayEventListener.php
+++ b/src/Provider/ApplePay/EventListener/CheckoutConfirmApplePayEventListener.php
@@ -49,7 +49,13 @@ class CheckoutConfirmApplePayEventListener implements EventSubscriberInterface
 
     private function isSafariBrowser(string $userAgent): bool
     {
-        return 'safari' === \strtolower((Parser::create())->parse($userAgent)->ua->family);
+        $browserFamily = \strtolower((Parser::create())->parse($userAgent)->ua->family);
+
+        return (
+            'safari' === $browserFamily
+            || 'chrome' === $browserFamily
+            || 'firefox' === $browserFamily
+        );
     }
 
     private function isSetup(): bool

--- a/src/Resources/views/storefront/component/checkout/apple-pay-button.html.twig
+++ b/src/Resources/views/storefront/component/checkout/apple-pay-button.html.twig
@@ -1,6 +1,6 @@
 {% block component_payone_apple_pay_button %}
     {% if constant('PayonePayment\\Provider\\ApplePay\\PaymentMethod\\StandardPaymentMethod::UUID') in page.paymentMethods|keys %}
-        <script src="https://applepay.cdn-apple.com/jsapi/v1/apple-pay-sdk.js"></script>
+        <script src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"></script>
 
         <input type="hidden" name="status" value=""/>
         <input type="hidden" name="txid" value=""/>


### PR DESCRIPTION
Updates the Apple Pay JS SDK script source to use the latest version (1.latest) instead of the fixed v1 to ensure compatibility with recent Apple Pay updates.
