### PR TITLE
Fix Apple Pay and Klarna handling for new orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,3 +534,10 @@ Maintenance
 Bugfixes
 
 * Fixed an error in sales channel management (occurring with administrative languages other than German and English) 
+
+# 7.3.2
+
+Bugfixes
+
+* Apple Pay: fixed issue with new orders
+* Klarna: improved handling for new orders

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -521,3 +521,10 @@ Maintenance
 Fehlerbehebung
 
 * Fehler in der Verkaufskanalverwaltung behoben (aufgetreten bei anderen Verwaltungssprachen als Deutsch und Englisch) 
+
+# 7.3.2
+
+Fehlerbehebung
+
+* Apple Pay: Problem bei neuen Bestellungen behoben
+* Klarna: Verbesserte Verarbeitung bei neuen Bestellungen

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payone-gmbh/shopware-6",
   "type": "shopware-platform-plugin",
   "description": "PAYONE Payment Plugin",
-  "version": "7.3.0",
+  "version": "7.3.2",
   "license": "MIT",
   "authors": [
     {

--- a/src/Provider/ApplePay/StoreApi/Route/ApplePayRoute.php
+++ b/src/Provider/ApplePay/StoreApi/Route/ApplePayRoute.php
@@ -14,10 +14,12 @@ use PayonePayment\RequestParameter\PaymentRequestEnricher;
 use PayonePayment\RequestParameter\RequestParameterEnricherChain;
 use PayonePayment\Service\OrderLoaderService;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
@@ -138,11 +140,14 @@ class ApplePayRoute extends AbstractApplePayRoute
         $cart                = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
         $orderId             = $request->get('orderId');
 
-        $orderEntity = match ($orderId) {
-            null    => $this->createFakeOrderEntity(),
+        if (!\is_string($orderId) || !Uuid::isValid($orderId)) {
+            $orderId = null;
+        }
 
+        $orderEntity = match ($orderId) {
+            null    => $this->createFakeOrderEntity($salesChannelContext, $cart),
             default => $this->orderLoaderService->getOrderById(
-                (string) $orderId,
+                $orderId,
                 $salesChannelContext->getContext(),
             ),
         };
@@ -169,11 +174,14 @@ class ApplePayRoute extends AbstractApplePayRoute
         return new JsonResponse($response);
     }
 
-    private function createFakeOrderEntity(): OrderEntity
+    private function createFakeOrderEntity(SalesChannelContext $salesChannelContext, Cart $cart): OrderEntity
     {
         $orderEntity = new OrderEntity();
 
         $orderEntity->setId(self::EMPTY_ORDER_ID);
+        $orderEntity->setCurrencyId($salesChannelContext->getCurrencyId());
+        $orderEntity->setSalesChannelId($salesChannelContext->getSalesChannelId());
+        $orderEntity->setAmountTotal($cart->getPrice()->getTotalPrice());
 
         return $orderEntity;
     }

--- a/src/Provider/Klarna/Service/KlarnaSessionService.php
+++ b/src/Provider/Klarna/Service/KlarnaSessionService.php
@@ -16,6 +16,7 @@ use PayonePayment\RequestParameter\PaymentRequestEnricher;
 use PayonePayment\RequestParameter\RequestParameterEnricherChain;
 use PayonePayment\Service\CartHasherService;
 use PayonePayment\Storefront\Struct\CheckoutKlarnaSessionData;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -67,13 +68,14 @@ readonly class KlarnaSessionService
 
         $cart          = $this->cartService->getCart($salesChannelContext->getToken(), $salesChannelContext);
         $cartHash      = $this->cartHasher->generate($order ?? $cart, $salesChannelContext);
+        $order         = $order ?? $this->createFakeOrderEntity($salesChannelContext, $cart);
         $paymentMethod = $this->paymentMethodRegistry->get(
             $salesChannelContext->getPaymentMethod()->getTechnicalName(),
         );
 
         $request = $this->paymentRequestEnricher->enrich(
             new PaymentRequestDto(
-                new PaymentTransactionDto(new OrderTransactionEntity(), $order ?? $this->createFakeOrderEntity(), []),
+                new PaymentTransactionDto(new OrderTransactionEntity(), $order, []),
                 new RequestDataBag(),
                 $salesChannelContext,
                 $cart,
@@ -93,11 +95,14 @@ readonly class KlarnaSessionService
         );
     }
 
-    private function createFakeOrderEntity(): OrderEntity
+    private function createFakeOrderEntity(SalesChannelContext $salesChannelContext, Cart $cart): OrderEntity
     {
         $orderEntity = new OrderEntity();
 
         $orderEntity->setId(self::EMPTY_ORDER_ID);
+        $orderEntity->setCurrencyId($salesChannelContext->getCurrencyId());
+        $orderEntity->setSalesChannelId($salesChannelContext->getSalesChannelId());
+        $orderEntity->setAmountTotal($cart->getPrice()->getTotalPrice());
 
         return $orderEntity;
     }


### PR DESCRIPTION
Ensures that placeholder order entities used during the checkout process are initialized with the correct currency, sales channel, and total amount. This prevents processing errors in Apple Pay and Klarna for orders that have not yet been persisted.

Fixes #389