### PR TITLE
version bump to 732

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -543,5 +543,5 @@ Bugfixes
 
 * Fixed a partial refund error for credit card transactions
 * Apple Pay & Klarna: Fixed problems with identical reference number
-* Fixed incorrect column name in API and transaction log
+* Fixed incorrect column name in API log and transaction log
 

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -528,6 +528,6 @@ Fehlerbehebung
 
 Fehlerbehebung
 
-* Teilerstattungs-Problem bei Kreditkartentransaktionen behoben
+* Fehler bei Teilerstattungen in Kreditkartentransaktionen behoben
 * Apple Pay & Klarna: Probleme mit identischer Referenz-Nummer behoben
 * Falschen Spaltennamen in API- und Transkationslog korrigiert


### PR DESCRIPTION
Bugfixes

- Fixed a partial refund error for credit card transactions
- Apple Pay & Klarna: Fixed problems with identical reference number
- Fixed incorrect column name in API and transaction log