### PR TITLE
version bump to 733

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -554,5 +554,5 @@ New Features
 
 Bugfixes
 
-* Fix undefined array key access in partial payment check
+* Fixed undefined array key access in partial payment check
 * Credit Card: Validation error in the checkout (Compatibility adjustment for  Shopware 6.7.10.2)


### PR DESCRIPTION
New Features

- Google Pay: Button configuration integrated into the PAYONE settings
- Klarna: country restrictions removed

Bugfixes

- Fix undefined array key access in partial payment check
- Credit Card: Validation error in the checkout (Compatibility adjustment for Shopware 6.7.10.2)