### PR TITLE
version bump to 740

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -561,5 +561,5 @@ Bugfixes
 
 Maintenance
 
-* Apple Pay: Updates the SDK script to use the `1.latest` version, ensuring compatibility with the most recent version 1 features.
+* Apple Pay: Update to `1.latest` version, ensuring compatibility with the most recent version 1 features.
 * Fixed line items not being selectable for partial refunds on Credit Card / Click to Pay transactions

--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -548,5 +548,5 @@ Bugfixes
 
 Maintenance
 
-* Apple Pay: Aktualisiert das SDK-Skript auf die Version 1.latest, um die Kompatibilität mit den neuesten Funktionen der Version 1 sicherzustellen.
+* Apple Pay: Aktualisiert auf die Version 1.latest, um die Kompatibilität mit den neuesten Funktionen der Version 1 sicherzustellen.
 * Fehler behoben, durch den Positionen bei Teilerstattungen für Kreditkarten- / Click-to-Pay-Transaktionen nicht auswählbar waren


### PR DESCRIPTION
Maintenance

- Apple Pay: Updates the SDK script to use the 1.latest version, ensuring compatibility with the most recent version 1 features
- Fixed line items not being selectable for partial refunds on Credit Card / Click to Pay transactions