### PR TITLE
Add blocks to checkout confirm

### DIFF
--- a/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -41,9 +41,11 @@
 {% endblock %}
 
 {% block base_flashbags_checkout %}
-    <div id="payone-apple-pay-error" style="display: none;">
-        {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: "danger", content: 'PayonePayment.errorMessages.genericError'|trans  } %}
-    </div>
+    {% block base_flashbags_checkout_payone_error %}
+        <div id="payone-apple-pay-error" style="display: none;">
+            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: "danger", content: 'PayonePayment.errorMessages.genericError'|trans  } %}
+        </div>
+    {% endblock %}
 
     {{ parent() }}
 {% endblock %}
@@ -52,11 +54,13 @@
 {% block page_checkout_confirm %}
     {{ parent() }}
 
-    {% if page.extensions.payoneDeviceFingerprint and page.extensions.payoneDeviceFingerprint.snippet %}
-        {{ page.extensions.payoneDeviceFingerprint.snippet|raw }}
-    {% endif %}
+    {% block page_checkout_confirm_payone %}
+        {% if page.extensions.payoneDeviceFingerprint and page.extensions.payoneDeviceFingerprint.snippet %}
+            {{ page.extensions.payoneDeviceFingerprint.snippet|raw }}
+        {% endif %}
 
-    {% if page.extensions.payone and page.extensions.payone.template %}
-        {% sw_include page.extensions.payone.template %}
-    {% endif %}
+        {% if page.extensions.payone and page.extensions.payone.template %}
+            {% sw_include page.extensions.payone.template %}
+        {% endif %}
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
Hello Payone-Team, we cannot use some payment methods because the checkout of our customer is modified. To restore the functionality we have to copy the entire page_checkout_confirm from this plugin or remove the layout changes which is not truly possible. Introducing twig blocks would make this very easily:

Allows themes and plugins to override checkout main blocks and restore payone changes via block() function:

```TWIG
{% block page_checkout_confirm %}
    {# Shopware Core #}
    {{ block('page_checkout_confirm_header') }}
    {{ block('page_checkout_confirm_alerts') }}
    {{ block('page_checkout_confirm_address') }}
    {{ block('page_checkout_confirm_payment_shipping') }}
    {{ block('page_checkout_confirm_product_table') }}
    {{ block('page_checkout_confirm_tos') }}
    {{ block('page_checkout_confirm_hidden_line_items_information') }}

    {# Payone #}
    {% if block('page_checkout_confirm_payone') is defined %}
        {{ block('page_checkout_confirm_payone') }}
    {% endif %}
{% endblock %}
```

This allows checkout layout changes without breaking payment by payone like Click-To-Pay.
